### PR TITLE
Added expo-gradle-ext-vars to patch androidXBrowser version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,6 +2,9 @@
 
 buildscript {
     ext {
+// @generated begin expo-gradle-ext-vars - expo prebuild (DO NOT MODIFY) sync-8148aaab086ec9de5b452f1513ae6558139eed5f
+	androidXBrowser = "1.8.0"
+// @generated end expo-gradle-ext-vars
         buildToolsVersion = findProperty('android.buildToolsVersion') ?: '35.0.0'
         minSdkVersion = Integer.parseInt(findProperty('android.minSdkVersion') ?: '24')
         compileSdkVersion = Integer.parseInt(findProperty('android.compileSdkVersion') ?: '35')
@@ -9,7 +12,6 @@ buildscript {
         kotlinVersion = findProperty('android.kotlinVersion') ?: '1.9.25'
 
         ndkVersion = "26.1.10909125"
-        androidXBrowser = "1.8.0"
     }
     repositories {
         google()

--- a/app.json
+++ b/app.json
@@ -32,6 +32,12 @@
     "plugins": [
       "expo-router",
       [
+        "expo-gradle-ext-vars",
+        {
+          "androidXBrowser": "1.8.0"
+        }
+      ],
+      [
         "expo-build-properties",
         {
           "android": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "expo-constants": "~17.1.6",
         "expo-crypto": "~14.1.4",
         "expo-font": "~13.3.1",
+        "expo-gradle-ext-vars": "^0.1.3",
         "expo-haptics": "~14.1.4",
         "expo-linking": "~7.1.5",
         "expo-router": "~5.0.7",
@@ -6989,6 +6990,11 @@
         "expo": "*",
         "react": "*"
       }
+    },
+    "node_modules/expo-gradle-ext-vars": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/expo-gradle-ext-vars/-/expo-gradle-ext-vars-0.1.3.tgz",
+      "integrity": "sha512-gbRclqGfebkog597+ZyeH6RnMxb7jojQDOUMkjFLZYNRAYye2edcPW5MrJyNX2lu7PsZWKEBTT0H7DRElSKFxA=="
     },
     "node_modules/expo-haptics": {
       "version": "14.1.4",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "expo-constants": "~17.1.6",
     "expo-crypto": "~14.1.4",
     "expo-font": "~13.3.1",
+    "expo-gradle-ext-vars": "^0.1.3",
     "expo-haptics": "~14.1.4",
     "expo-linking": "~7.1.5",
     "expo-router": "~5.0.7",


### PR DESCRIPTION
Patch this issue:
https://github.com/proyecto26/react-native-inappbrowser/issues/475